### PR TITLE
feat: add colored output for task priorities

### DIFF
--- a/config/settings.cfg
+++ b/config/settings.cfg
@@ -1,0 +1,2 @@
+priority_colors=true
+date_format="%Y-%m-%d %H:%M"


### PR DESCRIPTION
Fixes #1 
- High priority tasks appear in red
- Medium priority tasks appear in yellow
- Low priority tasks appear in green
- Added color configuration to settings.cfg